### PR TITLE
[Bugfix 346397] Use session id as the filename.

### DIFF
--- a/src/client/linux/handler/minidump_descriptor.cc
+++ b/src/client/linux/handler/minidump_descriptor.cc
@@ -43,6 +43,7 @@ MinidumpDescriptor::MinidumpDescriptor(const MinidumpDescriptor& descriptor)
     : mode_(descriptor.mode_),
       fd_(descriptor.fd_),
       directory_(descriptor.directory_),
+      sessionid_(descriptor.sessionid_),
       c_path_(NULL),
       size_limit_(descriptor.size_limit_),
       address_within_principal_mapping_(
@@ -64,6 +65,7 @@ MinidumpDescriptor& MinidumpDescriptor::operator=(
   mode_ = descriptor.mode_;
   fd_ = descriptor.fd_;
   directory_ = descriptor.directory_;
+  sessionid_ = descriptor.sessionid_;
   path_.clear();
   if (c_path_) {
     // This descriptor already had a path set, so generate a new one.
@@ -80,17 +82,22 @@ MinidumpDescriptor& MinidumpDescriptor::operator=(
   return *this;
 }
 
+// NOTE: for android we really shouldnt be using the guid at all
 void MinidumpDescriptor::UpdatePath() {
   assert(mode_ == kWriteMinidumpToFile && !directory_.empty());
-
-  GUID guid;
-  char guid_str[kGUIDStringLength + 1];
-  if (!CreateGUID(&guid) || !GUIDToString(&guid, guid_str, sizeof(guid_str))) {
-    assert(false);
-  }
-
+  
   path_.clear();
-  path_ = directory_ + "/" + guid_str + ".dmp";
+  if (sessionid_.empty()) {
+    GUID guid;
+    char guid_str[kGUIDStringLength + 1];
+    if (!CreateGUID(&guid) || !GUIDToString(&guid, guid_str, sizeof(guid_str))) {
+      assert(false);
+    }
+    path_ = directory_ + "/" + guid_str + ".dmp";
+  }
+  else {
+    path_ = directory_ + "/" + sessionid_ + ".dmp";
+  }
   c_path_ = path_.c_str();
 }
 

--- a/src/client/linux/handler/minidump_descriptor.h
+++ b/src/client/linux/handler/minidump_descriptor.h
@@ -69,6 +69,19 @@ class MinidumpDescriptor {
     assert(!directory.empty());
   }
 
+  explicit MinidumpDescriptor(const string& directory, const string& sessionid)
+      : mode_(kWriteMinidumpToFile),
+        fd_(-1),
+        directory_(directory),
+        sessionid_(sessionid),
+        c_path_(NULL),
+        size_limit_(-1),
+        address_within_principal_mapping_(0),
+        skip_dump_if_principal_mapping_not_referenced_(false),
+        sanitize_stacks_(false) {
+    assert(!directory.empty());
+  }
+
   explicit MinidumpDescriptor(int fd)
       : mode_(kWriteMinidumpToFd),
         fd_(fd),
@@ -100,6 +113,8 @@ class MinidumpDescriptor {
   string directory() const { return directory_; }
 
   const char* path() const { return c_path_; }
+
+  string sessionid() const { return sessionid_; }
 
   bool IsMicrodumpOnConsole() const {
     return mode_ == kWriteMicrodumpToConsole;
@@ -155,6 +170,9 @@ class MinidumpDescriptor {
 
   // The directory where the minidump should be generated.
   string directory_;
+
+  // The session id of the telemetry session
+  string sessionid_;
 
   // The full path to the generated minidump.
   string path_;


### PR DESCRIPTION
Change originally submitted via https://github.com/Mojang/Minecraftpe/pull/23994